### PR TITLE
add min/max for step_div

### DIFF
--- a/awake.lua
+++ b/awake.lua
@@ -222,7 +222,7 @@ function init()
     end}
   params:add_separator()
   
-  params:add{type = "number", id = "step_div", name = "step division", default = 4}
+  params:add{type = "number", id = "step_div", name = "step division", min = 1, max = 16, default = 4}
 
   params:add{type = "option", id = "note_length", name = "note length",
     options = {"25%", "50%", "75%", "100%"},


### PR DESCRIPTION
Step division param was causing noise and errors if the value went to zero or negative. Adding min and max to constrain values.

Would this be better with an option type and values like `{"1/4", "1/3", "1/2", "1", etc...}` ?