### PR TITLE
increase target midi device count

### DIFF
--- a/lib/halfsecond.lua
+++ b/lib/halfsecond.lua
@@ -32,7 +32,7 @@ function sc.init()
 	softcut.filter_bp(1, 1.0);
 	softcut.filter_rq(1, 2.0);
 
-  params:add_separator()
+  params:add_group("halfsecond params",4)
   params:add{id="delay", name="delay", type="control", 
     controlspec=controlspec.new(0,1,'lin',0,0.5,""),
     action=function(x) softcut.level(1,x) end}


### PR DESCRIPTION
added some tiny things to keep awake aligned with new scripting conventions:
- script can target all 16 midi vports
- names of midi vport devices visible in params
- add mappable triggers for sequence stop/start/reset
- group script params