### PR TITLE
Update awake.lua version to avoid misunderstanding with version distributed with norns

### DIFF
--- a/awake.lua
+++ b/awake.lua
@@ -1,5 +1,5 @@
 -- awake: time changes
--- 2.4.0 @tehn
+-- 2.4.1 @tehn
 -- llllllll.co/t/21022
 --
 -- top loop plays notes


### PR DESCRIPTION
The version of awake distributed with the official SD card at the moment of writing is marked 2.4.0 but is significantly different from the one that is live one on GitHub from @tehn, and is about 60 lines shorter, e.g. it lacks completely the management of MIDI start and stop messages. By marking the live version as a 2.4.1 revision we can avoid ambiguity for other users like me. Thanks!