### PR TITLE
fix: reset positions to 0

### DIFF
--- a/awake.lua
+++ b/awake.lua
@@ -1,5 +1,5 @@
 -- awake: time changes
--- 2.6.0 @tehn
+-- 2.7.0 @tehn
 -- l.llllllll.co/awake
 --
 -- top loop plays notes
@@ -202,11 +202,12 @@ function start()
 end
 
 function reset()
-  one.pos = 1
-  two.pos = 1
+  one.pos = 0
+  two.pos = 0
 end
 
 function clock.transport.start()
+  reset()
   start()
 end
 


### PR DESCRIPTION
just combing through the comments in https://github.com/monome/norns/pull/1738, i noticed that @ambv correct identified an issue about `awake`'s reset behavior: https://github.com/monome/norns/pull/1738#issuecomment-1817860981

this PR corrects the positions for the two sequences upon `reset()` and adds a `reset()` call to the `clock.transport.start()` callback.

also, version bump to reflect #22 and #23 and #24 :)